### PR TITLE
Add GitHub Actions workflow for automatic deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,57 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch: # Allows manual triggering from the Actions tab
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build project
+        run: npm run build
+        env:
+          CI: false # Prevents treating warnings as errors
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./build
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,0 +1,93 @@
+# Deployment Guide
+
+This site is configured to automatically deploy to GitHub Pages whenever changes are pushed to the `main` branch.
+
+## Automatic Deployment
+
+The site uses GitHub Actions to automatically build and deploy on every push to `main`. The workflow:
+
+1. Checks out the code
+2. Installs dependencies
+3. Builds the React app
+4. Deploys to GitHub Pages
+
+**No manual deployment needed!** Just merge your changes to `main` and the site will automatically update.
+
+## GitHub Pages Settings
+
+Make sure your repository settings are configured:
+
+1. Go to: Settings → Pages
+2. **Source**: GitHub Actions (not "Deploy from a branch")
+3. **Custom domain**: tylercartwright.co.uk
+4. **Enforce HTTPS**: Enabled
+
+## CNAME Configuration
+
+The `public/CNAME` file contains your custom domain (tylercartwright.co.uk). This file is automatically included in deployments and should not be removed.
+
+## Manual Deployment (Optional)
+
+If you need to manually deploy (e.g., for testing):
+
+```bash
+npm run deploy
+```
+
+This uses `gh-pages` package to deploy the build folder to the `gh-pages` branch.
+
+## Workflow File
+
+The deployment workflow is defined in `.github/workflows/deploy.yml`. It:
+
+- Triggers on push to `main` branch
+- Can be manually triggered from the Actions tab
+- Uses Node.js 18
+- Builds with `CI=false` to prevent warnings from failing the build
+
+## Troubleshooting
+
+### 500 Internal Server Error
+
+If you see a 500 error:
+
+1. Check the Actions tab to see if the deployment succeeded
+2. Verify GitHub Pages settings (Settings → Pages)
+3. Make sure "Source" is set to "GitHub Actions" (not gh-pages branch)
+4. Wait a few minutes for DNS propagation after deployment
+
+### Build Failures
+
+Check the Actions tab for detailed error logs. Common issues:
+
+- Missing dependencies: Run `npm ci` locally first
+- Build errors: Run `npm run build` locally to test
+- Node version mismatch: Workflow uses Node 18
+
+### Custom Domain Not Working
+
+1. Verify `public/CNAME` contains: `tylercartwright.co.uk`
+2. Check DNS settings point to GitHub Pages
+3. Wait for DNS propagation (can take up to 24 hours)
+4. Re-verify custom domain in Settings → Pages
+
+## Development Workflow
+
+1. Create a feature branch (e.g., `claude/redesign-portfolio-2025-*`)
+2. Make your changes
+3. Test locally with `npm start`
+4. Build and test with `npm run build`
+5. Commit and push to your branch
+6. Create a pull request to `main`
+7. Merge to `main` → Automatic deployment!
+
+## First Time Setup
+
+If switching from gh-pages branch deployment to GitHub Actions:
+
+1. Push this code to `main` branch
+2. Go to Settings → Pages
+3. Change Source from "Deploy from a branch" to "GitHub Actions"
+4. The next push to `main` will automatically trigger deployment
+
+That's it! Your site will now auto-deploy on every push to main.


### PR DESCRIPTION
- Configure automatic deployment to GitHub Pages on push to main
- Use GitHub Actions instead of manual gh-pages deployment
- Add comprehensive deployment documentation
- Fix 500 internal server error by switching from gh-pages branch to GitHub Actions deployment

The workflow automatically builds and deploys the React app whenever changes are pushed to main branch.

Setup required:
1. Merge this to main branch
2. Go to Settings → Pages
3. Change Source to "GitHub Actions" (instead of "Deploy from a branch")
4. Custom domain and CNAME configuration preserved